### PR TITLE
Conform to portable contacts schema

### DIFF
--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -3,9 +3,9 @@ var express = require('express')
   , util = require('util')
   , BoxStrategy = require('passport-box').Strategy;
 
-var BOX_CLIENT_ID = "---your--box--client--id---"
-var BOX_CLIENT_SECRET = "---your--box--client--secret--";
-
+var BOX_CLIENT_ID     = "kjqlzn6few9c7u327l92fcj2rp8scani" // your box client id
+  , BOX_CLIENT_SECRET = "QgUwm5wuofWzDPw3SNcU4Kh5EV6cNVQS" // you box secret
+  , BOX_APP_PORT      = 8080;                              // port you registered with box
 
 // Passport session setup.
 //   To support persistent login sessions, Passport needs to be able to
@@ -15,11 +15,11 @@ var BOX_CLIENT_SECRET = "---your--box--client--secret--";
 //   have a database of user records, the complete Box profile is
 //   serialized and deserialized.
 passport.serializeUser( function(user, done) {
-	done(null, user);
+  done(null, user);
 });
 
 passport.deserializeUser( function(obj, done) {
-	done(null, obj);
+  done(null, obj);
 });
 
 
@@ -28,45 +28,49 @@ passport.deserializeUser( function(obj, done) {
 //   credentials (in this case, an accessToken, refreshToken, and 37signals
 //   profile), and invoke a callback with a user object.
 passport.use(new BoxStrategy({
-    clientID: BOX_CLIENT_ID,
-    clientSecret: BOX_CLIENT_SECRET,
-    callbackURL: "http://127.0.0.1:3000/auth/box/callback"
-  },
-  function(accessToken, refreshToken, profile, done) {
-    // asynchronous verification, for effect...
-    process.nextTick(function () {
-      
-      // To keep the example simple, the user's Box profile is returned to
-      // represent the logged-in user.  In a typical application, you would want
-      // to associate the Box account with a user record in your database,
-      // and return that user instead.
-      return done(null, profile);
-    });
-  }
+  clientID: BOX_CLIENT_ID,
+  clientSecret: BOX_CLIENT_SECRET,
+  callbackURL: 'http://localhost:' + BOX_APP_PORT + '/auth/box/callback'
+},
+function(accessToken, refreshToken, profile, done) {
+  // asynchronous verification, for effect...
+  process.nextTick(function () {
+
+    // To keep the example simple, the user's Box profile is returned to
+    // represent the logged-in user.  In a typical application, you would want
+    // to associate the Box account with a user record in your database,
+    // and return that user instead.
+    return done(null, profile);
+  });
+}
 ));
 
-
-
+// Simple route middleware to ensure user is authenticated.
+//   Use this route middleware on any resource that needs to be protected.  If
+//   the request is authenticated (typically via a persistent login session),
+//   the request will proceed.  Otherwise, the user will be redirected to the
+//   login page.
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) { return next(); }
+  res.redirect('/login')
+}
 
 var app = express();
 
 // configure Express
-app.configure(function() {
-  app.set('views', __dirname + '/views');
-  app.set('view engine', 'ejs');
-  app.use(express.logger());
-  app.use(express.cookieParser());
-  app.use(express.bodyParser());
-  app.use(express.methodOverride());
-  app.use(express.session({ secret: 'keyboard cat' }));
-  // Initialize Passport!  Also use passport.session() middleware, to support
-  // persistent login sessions (recommended).
-  app.use(passport.initialize());
-  app.use(passport.session());
-  app.use(app.router);
-  app.use(express.static(__dirname + '/public'));
-});
-
+app.set('views', __dirname + '/views');
+app.set('view engine', 'ejs');
+app.use(express.logger());
+app.use(express.cookieParser());
+app.use(express.bodyParser());
+app.use(express.methodOverride());
+app.use(express.session({ secret: 'keyboard cat' }));
+// Initialize Passport!  Also use passport.session() middleware, to support
+// persistent login sessions (recommended).
+app.use(passport.initialize());
+app.use(passport.session());
+app.use(app.router);
+app.use(express.static(__dirname + '/public'));
 
 app.get('/', function(req, res){
   res.render('index', { user: req.user });
@@ -85,38 +89,24 @@ app.get('/login', function(req, res){
 //   request.  The first step in Box authentication will involve
 //   redirecting the user to Box.com.  After authorization, Box
 //   will redirect the user back to this application at /auth/box/callback
-app.get('/auth/box',
-  passport.authenticate('box'),
-  function(req, res){
-    // The request will be redirected to Box for authentication, so this
-    // function will not be called.
-  });
+app.get('/auth/box', passport.authenticate('box'));
 
 // GET /auth/box/callback
 //   Use passport.authenticate() as route middleware to authenticate the
 //   request.  If authentication fails, the user will be redirected back to the
 //   login page.  Otherwise, the primary route function function will be called,
 //   which, in this example, will redirect the user to the home page.
-app.get('/auth/box/callback', 
-  passport.authenticate('box', { failureRedirect: '/login' }),
-  function(req, res) {
-    res.redirect('/');
-  });
+app.get('/auth/box/callback',
+    passport.authenticate('box', { failureRedirect: '/login' }),
+    function(req, res) {
+      res.redirect('/');
+    });
 
 app.get('/logout', function(req, res){
   req.logout();
   res.redirect('/');
 });
 
-app.listen(3000);
-
-
-// Simple route middleware to ensure user is authenticated.
-//   Use this route middleware on any resource that needs to be protected.  If
-//   the request is authenticated (typically via a persistent login session),
-//   the request will proceed.  Otherwise, the user will be redirected to the
-//   login page.
-function ensureAuthenticated(req, res, next) {
-  if (req.isAuthenticated()) { return next(); }
-  res.redirect('/login')
-}
+app.listen(BOX_APP_PORT, function(){
+  console.log('listening on port', BOX_APP_PORT);
+});

--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -3,9 +3,9 @@ var express = require('express')
   , util = require('util')
   , BoxStrategy = require('passport-box').Strategy;
 
-var BOX_CLIENT_ID     = "kjqlzn6few9c7u327l92fcj2rp8scani" // your box client id
-  , BOX_CLIENT_SECRET = "QgUwm5wuofWzDPw3SNcU4Kh5EV6cNVQS" // you box secret
-  , BOX_APP_PORT      = 8080;                              // port you registered with box
+var BOX_CLIENT_ID     = process.env.BOX_CLIENT_ID;     // your box client id
+  , BOX_CLIENT_SECRET = process.env.BOX_CLIENT_SECRET; // you box secret
+  , PORT              = process.env.PORT;              // port you registered with box
 
 // Passport session setup.
 //   To support persistent login sessions, Passport needs to be able to
@@ -30,7 +30,7 @@ passport.deserializeUser( function(obj, done) {
 passport.use(new BoxStrategy({
   clientID: BOX_CLIENT_ID,
   clientSecret: BOX_CLIENT_SECRET,
-  callbackURL: 'http://localhost:' + BOX_APP_PORT + '/auth/box/callback'
+  callbackURL: 'http://localhost:' + PORT + '/auth/box/callback'
 },
 function(accessToken, refreshToken, profile, done) {
   // asynchronous verification, for effect...
@@ -107,6 +107,6 @@ app.get('/logout', function(req, res){
   res.redirect('/');
 });
 
-app.listen(BOX_APP_PORT, function(){
-  console.log('listening on port', BOX_APP_PORT);
+app.listen(PORT, function(){
+  console.log('listening on port', PORT);
 });

--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -2,9 +2,9 @@
   "name": "passport-box-examples-login",
   "version": "0.0.0",
   "dependencies": {
-    "express": ">= 0.0.0",
+    "express": "< 4",
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
-    "passport-box": ">= 0.0.0"
+    "passport-box": "../../"
   }
 }

--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -6,5 +6,9 @@
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
     "passport-box": "../../"
+  },
+  "engines": {
+    "node": ">= 0.4.0",
+    "npm": ">= 2.x"
   }
 }

--- a/examples/login/views/account.ejs
+++ b/examples/login/views/account.ejs
@@ -1,2 +1,5 @@
 <p>ID: <%= user.id %></p>
-<p>Name: <%= user.name %></p>
+<p>Name: <%= user.displayName %></p>
+<pre>
+  <%= JSON.stringify(user, null, 2) %>
+</pre>

--- a/examples/login/views/index.ejs
+++ b/examples/login/views/index.ejs
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<title>Passport-box Example</title>
-	</head>
-	<body>
-		<% if (!user) { %>
-			<h2>Welcome! Please log in.</h2>
-			<p>
-			<a href="/">Home</a> | 
-			<a href="/login">Log In</a>
-			</p>
-		<% } else { %>
-			<h2>Hello, <%= user.name %>.</h2>
-			<p>
-			<a href="/">Home</a> | 
-			<a href="/account">Account</a> | 
-			<a href="/logout">Log Out</a>
-			</p>
-		<% } %>
-	</body>
+  <head>
+    <title>Passport-box Example</title>
+  </head>
+  <body>
+    <% if (!user) { %>
+      <h2>Welcome! Please log in.</h2>
+      <p>
+        <a href="/">Home</a> |
+        <a href="/login">Log In</a>
+      </p>
+    <% } else { %>
+      <h2>Hello, <%= user.displayName %>.</h2>
+      <p>
+        <a href="/">Home</a> |
+        <a href="/account">Account</a> |
+        <a href="/logout">Log Out</a>
+      </p>
+    <% } %>
+  </body>
 </html>

--- a/examples/login/views/layout.ejs
+++ b/examples/login/views/layout.ejs
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<title>Passport-box Example</title>
-	</head>
-	<body>
-		<% if (!user) { %>
-			<h2>Welcome! Please log in.</h2>
-			<p>
-			<a href="/">Home</a> | 
-			<a href="/login">Log In</a>
-			</p>
-		<% } else { %>
-			<h2>Hello, <%= user.displayName %>.</h2>
-			<p>
-			<a href="/">Home</a> | 
-			<a href="/account">Account</a> | 
-			<a href="/logout">Log Out</a>
-			</p>
-		<% } %>
-		<%- body %>
-	</body>
+  <head>
+    <title>Passport-box Example</title>
+  </head>
+  <body>
+    <% if (!user) { %>
+      <h2>Welcome! Please log in.</h2>
+      <p>
+        <a href="/">Home</a> |
+        <a href="/login">Log In</a>
+      </p>
+    <% } else { %>
+      <h2>Hello, <%= user.displayName %>.</h2>
+      <p>
+        <a href="/">Home</a> |
+        <a href="/account">Account</a> |
+        <a href="/logout">Log Out</a>
+      </p>
+    <% } %>
+    <%- body %>
+  </body>
 </html>

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,7 +1,8 @@
 var util = require('util')
   , OAuth2Strategy = require('passport-oauth').OAuth2Strategy
   , InternalOAuthError = require('passport-oauth').InternalOAuthError;
-  
+
+
 /**
  * `Strategy` constructor.
  *
@@ -14,10 +15,10 @@ var util = require('util')
  * credentials are not valid.  If an exception occured, `err` should be set.
  *
  * Options:
- *   - `clientId`      	your Box application's client id
- *   - `clientSecret`  	your Box application's client secret
- *   - `callbackURL`   	URL to which Box will redirect the user after granting authorization (optional of set in your Box Application
- *   - `grant_type`		Must be authorization_code
+ *   - `clientId`     your Box application's client id
+ *   - `clientSecret` your Box application's client secret
+ *   - `callbackURL`  URL to which Box will redirect the user after granting authorization (optional of set in your Box Application
+ *   - `grant_type`   Must be authorization_code
  *
  * Examples:
  *
@@ -38,15 +39,16 @@ var util = require('util')
  * @api public
  */
 function Strategy(options, verify) {
-	options = options || {};
-	// http://developers.box.com/oauth/
-	options.authorizationURL = options.authorizationURL || 'https://api.box.com/oauth2/authorize';
-	options.tokenURL = options.tokenURL || 'https://api.box.com/oauth2/token';
-	options.grant_type = options.grant_type || 'authorization_code';
-	
-	OAuth2Strategy.call(this, options, verify);
-	this.name = 'box';
+  options = options || {};
+  // http://developers.box.com/oauth/
+  options.authorizationURL = options.authorizationURL || 'https://api.box.com/oauth2/authorize';
+  options.tokenURL = options.tokenURL || 'https://api.box.com/oauth2/token';
+  options.grant_type = options.grant_type || 'authorization_code';
+
+  OAuth2Strategy.call(this, options, verify);
+  this.name = options.name || 'box';
 }
+
 
 /**
  * Inherit from `OAuth2Strategy`.
@@ -59,10 +61,12 @@ util.inherits(Strategy, OAuth2Strategy);
  *
  * This function constructs a normalized profile, with the following properties:
  *
- *   - `provider`         always set to `box`
- *   - `id`
- *   - `username`
- *   - `displayName`
+ *   - `provider`    // always set to `box`
+ *   - `id`          // box's user id
+ *   - `displayName` // box user's full name
+ *   - `name`        // name parts
+ *   - `emails`      // box login email
+ *   - `photos`      // box avatar
  *
  * @param {String} accessToken
  * @param {Function} done
@@ -71,17 +75,32 @@ util.inherits(Strategy, OAuth2Strategy);
 Strategy.prototype.userProfile = function(accessToken, done) {
   this._oauth2.get('https://api.box.com/2.0/users/me', accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    
+
     try {
-      var json = JSON.parse(body);
-      
-      var profile = { provider: 'box' };
+      var json = JSON.parse(body)
+        , nameParts = json.name.split(' ')
+        , profile = { };
+
+      // portable contacts schema
+      // http://passportjs.org/guide/profile/
+      profile.provider = 'box';
       profile.id = json.id;
-      profile.name = json.name;
+      profile.displayName = json.name;
+      profile.name = {
+        givenName: nameParts.shift(),
+        familyName: nameParts.pop(),
+        middleName: nameParts.join(' ')
+      };
+      profile.emails = [ { value: json.login } ];
+      profile.photos = [ { value: json.avatar_url } ];
+
+      // passport-box extra
       profile.login = json.login;
+
+      // passport extras
       profile._raw = body;
       profile._json = json;
-      
+
       done(null, profile);
     } catch(e) {
       done(e);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-box",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "box authentication strategy for Passport.",
   "keywords": ["passport", "box", "box.com", "oauth", "oauth 2.0", "auth", "api", "authentication", "bluedge", "bluedge.co.uk"],
   "repository": {
@@ -24,5 +24,8 @@
   "devDependencies": {
     "vows": "0.6.x"
   },
-  "engines": { "node": ">= 0.4.0" }
+  "engines": {
+    "node": ">= 0.4.0",
+    "npm": ">= 2.x"
+  }
 }


### PR DESCRIPTION
### passport-box
- Bump version to `0.2.0`
- Change profile output from box to match Portable Contacts schema
  - http://passportjs.org/guide/profile
##### Changes
- `profile.displayName` over `profile.name`
- `profile.name` is now an object

``` javascript
{ name: {
  givenName: 'firstName',
  middleName: 'middleName',
  familyName: 'lastName'
} }
```
#### passport-box-examples-login
- lock `express < 4`
- add `npm > 2` to engines
- add relative path to passport-box
- update views to use `displayName` (`name` is deprecated)
- added profile dump to account page (for clarity) 
